### PR TITLE
add guard clause for the function which work correctly only in nas mo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,19 @@ Here, I have build an interface and add some naive methods for add sparsity into
 - Cifar-100 command
     - training
         ```
-        python main.py \
+        python -m torch.distributed.launch --nporc_per_node=8 --use_env main.py \
             --model deit_small_patch16_224 \
-            --batch-size 256 \
+            --batch-size 128 \
             --finetune https://dl.fbaipublicfiles.com/deit/deit_small_patch16_224-cd65a155.pth \
             --data-set CIFAR \
-            --data-path /dataset/cifar100 \
-            --opt sgd \
-            --weight-decay 1e-4 \
-            --lr 1e-2 \
-            --output_dir deit_s_224_cifar_100 \
-            --epochs 500
+            --data-path /dev/shm/cifar100 \
+            --opt adamw \
+            --weight-decay 0.01 \
+            --lr 5e-6 \
+            --min-lr 1e-7 \
+            --drop-path 0.05 \
+            --output_dir deit_s_224_cifar_100_0629 \
+            --epochs 1000
         ```
 
 ## Support Sparsity Searching Algorithm

--- a/main.py
+++ b/main.py
@@ -293,9 +293,14 @@ def main(args):
             mixup_alpha=args.mixup, cutmix_alpha=args.cutmix, cutmix_minmax=args.cutmix_minmax,
             prob=args.mixup_prob, switch_prob=args.mixup_switch_prob, mode=args.mixup_mode,
             label_smoothing=args.smoothing, num_classes=args.nb_classes)
-    
-    with open(args.nas_config) as f:
-        nas_config = yaml.load(f, Loader=SafeLoader)  
+    if args.nas_mode:
+        if args.nas_config:
+            with open(args.nas_config) as f:
+                nas_config = yaml.load(f, Loader=SafeLoader) 
+        else:
+            raise ValueError("Please provide the nas config when you are running in nas mode")
+    else:
+        nas_config = None
     
     print(f"Creating model: {args.model}")
     model = create_model(


### PR DESCRIPTION
This MR fix the bug when running with CIFAR training when disable nas_mode by adding a guard clause to avoid the function only support in nas_model being invoke